### PR TITLE
Dockerfile: Switch to using base images by arch

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,7 @@
 # base-image for node on any machine using a template variable,
 # see more about dockerfile templates here: https://www.balena.io/docs/learn/develop/dockerfile/#dockerfile-templates
 # and about balena base images here: https://www.balena.io/docs/reference/base-images/base-images/
-FROM balenalib/%%BALENA_MACHINE_NAME%%-node:14-buster-run
+FROM balenalib/%%BALENA_ARCH%%-node:14-buster-run
 
 # use `install_packages` if you need to install dependencies,
 # for instance if you need git, just uncomment the line below.
@@ -19,9 +19,6 @@ RUN JOBS=MAX npm install --production --unsafe-perm && npm cache verify && rm -r
 
 # This will copy all files in our root to the working directory in the container
 COPY . ./
-
-# Enable udevd so that plugged dynamic hardware devices show up in our container.
-ENV UDEV=1
 
 # server.js will run when container starts up on the device
 CMD ["npm", "start"]


### PR DESCRIPTION
Private DTs do not have base images, so switching
to using images by arch simplifies automated
testing for them.

We also remove UDEV since it's not needed
for this particular application and throws
the following warning in the application logs:
   balena-hello-world  Unable to start udev,
   container must be run in privileged mode to start udev!

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>