### PR TITLE
Explicitly set version in balena.yml

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,5 +1,6 @@
 name: balena-nodejs-hello-world
 type: sw.application
+version: 0.0.0
 joinable: false
 description: >-
   This is a simple skeleton NodeJS server that works on any of the devices supported by balena. It also serves as a boilerplate project for you to get started on building your fleet. Have fun! 


### PR DESCRIPTION
If you push the current project without having the version defined, it won't allow you to add it later. There appears to be some issue with caching in the builder, so using `--no-cache` will fix the behaviour, but I think we should add this explicitly so the user can have it working from the start and as its easy to learn from seeing it present in the file.