### PR TITLE
patch: Replace base image with Docker Official base image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,11 +1,7 @@
 # base-image for node on any machine using a template variable,
 # see more about dockerfile templates here: https://www.balena.io/docs/learn/develop/dockerfile/#dockerfile-templates
 # and about balena base images here: https://www.balena.io/docs/reference/base-images/base-images/
-FROM balenalib/%%BALENA_ARCH%%-node:20-run
-
-# use `install_packages` if you need to install dependencies,
-# for instance if you need git, just uncomment the line below.
-# RUN install_packages git
+FROM node:22-bookworm-slim
 
 # Defines our working directory in container
 WORKDIR /usr/src/app


### PR DESCRIPTION
Replacing balenalib image with Docker Official image

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
